### PR TITLE
Add Dependabot config for daily npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    groups:
+      daily-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Add .github/dependabot.yml (version: 2) to enable daily npm dependency updates on the master branch. Limits open PRs to 1, groups minor and patch updates into a single group (daily-minor-and-patch) for the repository root, and ignores semver-major version updates.