### PR TITLE
Increase Dependabot PR limit and expand README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     groups:
       minor-and-patch:
         patterns:

--- a/README.md
+++ b/README.md
@@ -1,60 +1,106 @@
 # Budget App
 
-A React budget tracker built with Vite.
+Budget App is a small React budget tracker for recording income and expenses and viewing the running balance in real time.
+
+## Current Functionality
+
+- Add income and expense transactions from a single form.
+- Keep separate transaction lists for income and expenses.
+- Recalculate total budget, total income, and total expenses immediately after each submission.
+- Show a simple, single-page dashboard with a summary header and transaction lists.
+
+## Tech Stack
+
+- React 19
+- Vite 7
+- Vitest and Testing Library
+- ESLint
 
 ## Prerequisites
 
-Use Node.js 24 LTS. This repository pins Node `24.15.0` in `.nvmrc`, and `package.json` requires `>=24 <25`.
+Use Node.js 24 LTS. This repository pins `24.15.0` in `.nvmrc`, and `package.json` requires `>=24 <25`.
+
+## Getting Started
 
 ```sh
 nvm use
 npm ci
 ```
 
-## Available Scripts
-
-Run the development server:
+Start the development server:
 
 ```sh
 npm run dev
 ```
 
-The app opens at [http://localhost:3000](http://localhost:3000).
+The Vite dev server opens automatically at [http://localhost:3000](http://localhost:3000).
 
-Run tests:
+## Scripts
 
-```sh
-npm test
-```
+`npm run dev`
 
-Run the test UI:
+Starts the Vite development server on port 3000.
 
-```sh
-npm run test:ui
-```
+`npm test`
 
-Run coverage:
+Runs the Vitest suite in watch mode.
 
-```sh
-npm run test:coverage
-```
+`npm test -- --run`
 
-Run linting:
+Runs the test suite once and exits.
 
-```sh
-npm run lint
-```
+`npm run test:ui`
 
-Build the production bundle:
+Starts the Vitest UI.
 
-```sh
-npm run build
-```
+`npm run test:coverage`
 
-The production output is written to `dist`.
+Generates a coverage report.
 
-Preview the production build locally:
+`npm run lint`
 
-```sh
-npm run preview
+Lints the source files in `src`.
+
+`npm run lint:fix`
+
+Lints the source files in `src` and applies safe automatic fixes.
+
+`npm run build`
+
+Builds the production bundle into `dist`.
+
+`npm run preview`
+
+Serves the production build locally for verification.
+
+## Testing and Validation
+
+The project currently includes a basic render test for the root app component.
+
+Validated commands:
+
+- `npm test -- --run`
+- `npm run lint`
+- `npm run build`
+
+## Current Limitations
+
+- Transactions are stored only in component state and are lost on refresh.
+- The budget heading currently hardcodes the month as `November`.
+- The form does not prevent empty or zero-value submissions beyond native input behavior.
+- There is only minimal automated test coverage at the moment.
+
+## Project Structure
+
+```text
+src/
+	App.jsx
+	App.css
+	index.jsx
+	index.css
+	Components/
+		addTransaction.jsx
+		ListTransactions.jsx
+		totalBudget.jsx
+		Transaction.jsx
 ```


### PR DESCRIPTION
Bump Dependabot open-pull-requests-limit from 3 to 5 to allow more concurrent dependency update PRs. Substantially expand README: add app summary, current functionality, tech stack, clarified prerequisites and Getting Started steps, consolidate and correct script usage, add testing/validation notes, list current limitations, and include a basic project structure. These changes improve onboarding and developer clarity.